### PR TITLE
chatgpt prompt update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,14 +19,15 @@ jobs:
           url: https://github.com/grafana/grafana/issues/77598
           type: issue
           prompt: "
-            I want you to help me apply the right GitHub label to an issue, and help me generate a summary of that issue.
-            Ensure your response is syntactically valid JSON.  Output one object with three keys, type, area, and summary.
+            I want you to help me categorize a GitHub issue by applying the right GitHub label to the issue, and help me generate a summary of that issue.
+            
+            Ensure your response is syntactically valid JSON. Output one object with three keys, type, area, and summary.
             The type and area keys can be JSON arrays of 1 or more choices of labels from the sets below. The summary
             must be a single string.
 
             You may choose more than one label for type and area, as a JSON array of strings, but only one summary
-            string.
-              
+            string. In addition, if the issue contains the word 'security' or some other cyber-security related term, add the 'area/security' label always.
+            
             Here is the list of type labels, please choose a type label only from this list:
               type/accessibility
               type/angular-2-react
@@ -222,8 +223,7 @@ jobs:
               area/ui/theme
               area/units
               area/ux
-              area/value-mapping
-            "
+              area/value-mapping"
       - name: Output 
         run: echo "${{ steps.test_action.outputs.output }}"
       - name: Errors 


### PR DESCRIPTION
Hi @moxious ,

I reviewed the chatgpt workflow and these are my comments and suggestions.

In `main.yml`, I tried to clarify that we want to 'categorize' (even though I'm not sure that this will help), and that if the issue contains any security related term, that it should always add the `area/security label`.

Besides that, I think there is a little contradiction in the instructions. ChatGPT is being instructed to add one or more labels for type and area, but later it is told to chose only one of each from the lists (I haven't changed that though).

As for "How do you do triage?":

I think overall there are enough instructions for chatgpt to triage the issue. But, it is true that there are a couple more things that I do.

Based on the [flowchart diagram](https://github.com/grafana/grafana/blob/main/ISSUE_TRIAGE.md#simplified-flowchart-diagram-of-the-issue-triage-process) for the issue triage process:

- I am not sure that we can instruct chatgpt to use the label 'needs more info' correctly. Can Chatgpt determine
 whether or not the issue has enough info to be reproduced? I see the label was left out anyway.

- It would be great if the program could include a function to search for potential duplicates. ChatGPT cannot be simply instructed
to follow a link and search for issues (I tried). This would require that the program would first grab the subject of the given issue,  make a
new search in github, look into, let's say the top 5 returned issues, and iterarte over the issues' description. And if there was a "match", then report back 
to the original issue with the issue number of the potential duplicate.

- the priority is something that we actually never touch

- assigning to a project would be great, but like you said, we need to see how chatgpt performs vs a trained model.


That's all for now. I hope any of this helps. Let me know if I can help with anything else!